### PR TITLE
DDCNL-1318: Lowered the priority of Log

### DIFF
--- a/app/utils/ParserUtil.scala
+++ b/app/utils/ParserUtil.scala
@@ -37,7 +37,7 @@ trait ParserUtil {
   def formatDataToValidate(rowData: Seq[String], sheetName: String): Seq[String] = {
     val sheetColSize = ERSTemplatesInfo.ersSheets(sheetName.replace(".csv", "")).headerRow.size
     if(rowData.size < sheetColSize) {
-      Logger.warn(s"Difference between amount of columns ${rowData.size} and amount of headers $sheetColSize")
+      Logger.debug(s"Difference between amount of columns ${rowData.size} and amount of headers $sheetColSize")
       val additionalEmptyCells: Seq[String] = Seq.fill(sheetColSize - rowData.size)("")
       (rowData ++ additionalEmptyCells).take(sheetColSize)
     }


### PR DESCRIPTION
Logging at warning priority was causing containers to fail when large files (250k+ lines). Debug priority more appropriate at the current time, performance improvements needed, but inappropriate at this moment