### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,10 +51,6 @@ security.headers.filter.enabled = true
 play {
 	filters {
 		csrf {
-			header.bypassHeaders {
-				X-Requested-With = "*"
-				Csrf-Token = "nocheck"
-			}
 			contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
 		}
 		headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9250 localhost:9570 localhost:9032 assets.digital.cabinet-office.gov.uk www.google-analytics.com data:"


### PR DESCRIPTION
A large number of configuration files in production contains code which allows the anti-csrf checks to be bypassed.

The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051