### PR TITLE
DDCE-184: Fixed caching conflict issue causing journey tests to fail

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -52,8 +52,8 @@ class UploadController @Inject()(authAction: AuthAction,
   def clearCache()(implicit request: RequestWithOptionalEmpRef[AnyContent], hc: HeaderCarrier): Future[Boolean] = {
     //remove function doesn't work, the cache needs to be overwritten with 'blank' data
     (for {
-      _  	<-	ersUtil.cache[Long](ersUtil.SCHEME_ERROR_COUNT_CACHE, 0L)
-      _	 	<-	ersUtil.cache[ListBuffer[SheetErrors]](ersUtil.ERROR_LIST_CACHE, new ListBuffer[SheetErrors]())
+      _   <-  ersUtil.cache[Long](ersUtil.SCHEME_ERROR_COUNT_CACHE, 0L)
+      _   <-  ersUtil.cache[ListBuffer[SheetErrors]](ersUtil.ERROR_LIST_CACHE, new ListBuffer[SheetErrors]())
     } yield {
       Logger.debug(s"[UploadController][clearCache] Successfully cleared cache")
       true

--- a/app/controllers/UpscanController.scala
+++ b/app/controllers/UpscanController.scala
@@ -24,6 +24,7 @@ import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.SessionService
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import utils.{ERSUtil, Retryable}
 
@@ -42,9 +43,22 @@ class UpscanController @Inject()(authAction: AuthAction,
     Future.successful(getGlobalErrorPage)
   }
 
+
+  def fetchCsvCallbackList(list: UpscanCsvFilesList, sessionId: String)
+                          (implicit hc: HeaderCarrier, request: Request[_]): Future[Seq[UpscanCsvFilesCallback]] = {
+    Future.sequence {
+      list.ids map { head =>
+        ersUtil.fetch[UpscanIds](head.uploadId.value, sessionId) map { upscanId =>
+          UpscanCsvFilesCallback(upscanId.uploadId, upscanId.uploadStatus)
+        }
+      }
+    }
+}
+
   def successCSV(uploadId: UploadId, scheme: String): Action[AnyContent] = authAction.async { implicit request =>
-    Logger.debug(s"[UpscanController][successCSV] Upload form submitted for ID: $uploadId")
+    Logger.info(s"[UpscanController][successCSV] Upload form submitted for ID: $uploadId")
     val sessionId = hc.sessionId.get.value
+
     val upscanCsvFilesList = for {
       csvFileList   <- ersUtil.fetch[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD, sessionId)
       updatedCacheFileList = {
@@ -54,13 +68,19 @@ class UpscanController @Inject()(authAction: AuthAction,
       _ <- ersUtil.cache(ersUtil.CSV_FILES_UPLOAD, updatedCacheFileList, sessionId)
     } yield updatedCacheFileList
 
-    upscanCsvFilesList flatMap  { fileList =>
+    upscanCsvFilesList flatMap { fileList =>
       if(fileList.noOfFilesToUpload == fileList.noOfUploads) {
-        sessionService.getCallbackRecordCsv(sessionId).withRetry(appConfig.allCsvFilesCacheRetryAmount){ list =>
-          Logger.debug(s"[UpscanController][successCSV] Comparing cached files [${list.files.size}] to numberOfFileToUpload[${fileList.noOfFilesToUpload}]")
-          list.files.size == fileList.noOfFilesToUpload
-        } map { callbackData =>
-          if(callbackData.areAllFilesComplete() && callbackData.areAllFilesSuccessful()) {
+        fetchCsvCallbackList(fileList, sessionId).withRetry(appConfig.allCsvFilesCacheRetryAmount){ list =>
+          Logger.debug(s"[UpscanController][successCSV] Fetched Callback list - $list")
+          Logger.info(s"[UpscanController][successCSV] Comparing cached files [${list.size}] to numberOfFileToUpload[${fileList.noOfFilesToUpload}]")
+          Logger.info(s"[UpscanController][successCSV] Checking if all files have completed upload - [${list.forall(_.isComplete)}]")
+
+
+          (list.size == fileList.noOfFilesToUpload) && list.forall(_.isComplete)
+        } map { files =>
+          val callbackData = UpscanCsvFilesCallbackList(files.toList.reverse)
+          sessionService.createCallbackRecordCSV(callbackData, sessionId)
+          if(callbackData.areAllFilesSuccessful()) {
             Redirect(routes.UploadController.uploadCSVFile(scheme))
           } else {
             Logger.error(s"[UpscanController][successCSV] Not all files are completed uploading - (${callbackData.areAllFilesComplete()}) " +
@@ -69,7 +89,7 @@ class UpscanController @Inject()(authAction: AuthAction,
           }
         } recover {
           case e: Exception =>
-            Logger.error(s"success: failed to fetch callback data with exception ${e.getMessage}," +
+            Logger.error(s"[UpscanController][successCSV] failed to fetch callback data with exception ${e.getMessage}," +
               s"timestamp: ${System.currentTimeMillis()}.", e)
             getGlobalErrorPage
         }

--- a/app/services/SessionService.scala
+++ b/app/services/SessionService.scala
@@ -30,17 +30,11 @@ class SessionService @Inject()(val ersUtil: ERSUtil) {
 	val CALLBACK_DATA_KEY = "callback_data_key"
 	val CALLBACK_DATA_KEY_CSV = "callback_data_key_csv"
 
-
-	def createCallbackRecordCsv(sessionId: String)
-														 (implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[CacheMap] = {
-		ersUtil.cache(CALLBACK_DATA_KEY_CSV, UpscanCsvFilesCallbackList(List[UpscanCsvFilesCallback]()), sessionId)
-	}
-
 	def createCallbackRecord(implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[CacheMap] = {
 		ersUtil.cache[UploadStatus](CALLBACK_DATA_KEY, NotStarted)
 	}
 
-	def updateCallbackRecordCsv(callbackList: UpscanCsvFilesCallbackList, sessionId: String)
+	def createCallbackRecordCSV(callbackList: UpscanCsvFilesCallbackList, sessionId: String)
 														 (implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[CacheMap] = {
 		ersUtil.cache(CALLBACK_DATA_KEY_CSV, callbackList, sessionId)
 	}
@@ -50,9 +44,4 @@ class SessionService @Inject()(val ersUtil: ERSUtil) {
 
 	def getCallbackRecord(implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Option[UploadStatus]] =
 		ersUtil.shortLivedCache.fetchAndGetEntry[UploadStatus](ersUtil.getCacheId, CALLBACK_DATA_KEY)
-
-	def getCallbackRecordCsv(sessionId: String)
-													(implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[UpscanCsvFilesCallbackList] = {
-		ersUtil.fetch[UpscanCsvFilesCallbackList](CALLBACK_DATA_KEY_CSV, sessionId)
-	}
 }

--- a/test/controllers/UpscanControllerSpec.scala
+++ b/test/controllers/UpscanControllerSpec.scala
@@ -24,8 +24,9 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.mvc.{DefaultMessagesControllerComponents, Result}
+import play.api.mvc.{DefaultMessagesControllerComponents, Request, Result}
 import services.{CsvFileProcessor, ProcessODSService}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
@@ -43,21 +44,28 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
   val mockProcessODSService: ProcessODSService = mock[ProcessODSService]
   val mockCsvFileProcessor: CsvFileProcessor = mock[CsvFileProcessor]
 
-  val upscanController: UpscanController = new UpscanController(mockAuthAction, mockSessionService, mcc, mockErsUtil, mockAppConfig) {
+  val uploadId: UploadId = UploadId("uploadId")
+  val upscanCsvFilesCallback: UpscanCsvFilesCallback = UpscanCsvFilesCallback(uploadId: UploadId, InProgress)
+  val upscanCsvFilesListCallbackList: UpscanCsvFilesCallbackList = UpscanCsvFilesCallbackList(files = List(upscanCsvFilesCallback))
+
+  def upscanController(csvList: UpscanCsvFilesCallbackList = upscanCsvFilesListCallbackList): UpscanController =
+    new UpscanController(mockAuthAction, mockSessionService, mcc, mockErsUtil, mockAppConfig) {
+    override def fetchCsvCallbackList(list: UpscanCsvFilesList, sessionId: String)
+                                     (implicit hc: HeaderCarrier, request: Request[_]): Future[Seq[UpscanCsvFilesCallback]] = {
+      Future.successful(csvList.files)
+    }
     mockAnyContentAction
   }
 
   "failure" should {
     "return a 200 when successful" in {
       val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET")
-      val result: Future[Result] = upscanController.failure().apply(fakeRequest)
+      val result: Future[Result] = upscanController().failure().apply(fakeRequest)
       status(result) shouldBe Status.OK
     }
   }
 
   "successCsv" should {
-    val uploadId = UploadId("uploadId")
-
     "redirect to the upload csv file page when the file file status is uploaded successfully" in {
       val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET")
       val successfully: UploadedSuccessfully = UploadedSuccessfully("thefilename", "downloadUrl", Some(1000))
@@ -68,9 +76,8 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
 
       when(mockErsUtil.fetch[UpscanCsvFilesList](any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(singleCsvFile))
       when(mockErsUtil.cache(any(), any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(null))
-      when(mockSessionService.getCallbackRecordCsv(any())(any(), any(), any())).thenReturn(Future.successful(upscanCsvFilesListCallbackList))
 
-      val result = upscanController.successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      val result = upscanController(upscanCsvFilesListCallbackList).successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.SEE_OTHER
       result.header.headers("Location") shouldBe routes.UploadController.uploadCSVFile(Fixtures.getMockSchemeTypeString).toString
     }
@@ -79,16 +86,12 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
       val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET")
       val upscanId: UpscanIds = UpscanIds(uploadId, "fileId", NotStarted)
       val singleCsvFile: UpscanCsvFilesList = UpscanCsvFilesList(ids = Seq(upscanId))
-      val upscanCsvFilesCallback= UpscanCsvFilesCallback(uploadId: UploadId, InProgress)
-      val upscanCsvFilesListCallbackList = UpscanCsvFilesCallbackList(files = List(upscanCsvFilesCallback))
 
       when(mockSessionService.ersUtil).thenReturn(mockErsUtil)
       when(mockErsUtil.fetch[UpscanCsvFilesList](any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(singleCsvFile))
-      when(mockSessionService.ersUtil).thenReturn(mockErsUtil)
       when(mockErsUtil.cache(any(), any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(null))
-      when(mockSessionService.getCallbackRecordCsv(any())(any(), any(), any())).thenReturn(Future.successful(upscanCsvFilesListCallbackList))
 
-      val result = upscanController.successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      val result = upscanController(upscanCsvFilesListCallbackList).successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.OK
     }
 
@@ -99,11 +102,18 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
 
       when(mockSessionService.ersUtil).thenReturn(mockErsUtil)
       when(mockErsUtil.fetch[UpscanCsvFilesList](any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(singleCsvFile))
-      when(mockSessionService.ersUtil).thenReturn(mockErsUtil)
       when(mockErsUtil.cache(any(), any(), any())(any(), any(), any(), any())).thenReturn(Future.successful(null))
-      when(mockSessionService.getCallbackRecordCsv(any())(any(), any(), any())).thenReturn(Future.failed(new Exception("error")))
 
-      val result = upscanController.successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      def upscanControllerError(): UpscanController =
+        new UpscanController(mockAuthAction, mockSessionService, mcc, mockErsUtil, mockAppConfig) {
+          override def fetchCsvCallbackList(list: UpscanCsvFilesList, sessionId: String)
+                                           (implicit hc: HeaderCarrier, request: Request[_]): Future[Seq[UpscanCsvFilesCallback]] = {
+            Future.failed(new Exception("error"))
+          }
+          mockAnyContentAction
+        }
+
+      val result = upscanControllerError().successCSV(uploadId, Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.OK
     }
   }
@@ -115,7 +125,7 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
 
       when(mockSessionService.getCallbackRecord(any(), any(), any())).thenReturn(Future.successful(Some(successfully)))
 
-      val result = upscanController.successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      val result = upscanController().successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.SEE_OTHER
       result.header.headers("Location") shouldBe routes.UploadController.uploadODSFile(Fixtures.getMockSchemeTypeString).toString
 
@@ -125,7 +135,7 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
       val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET")
       when(mockSessionService.getCallbackRecord(any(), any(), any())).thenReturn(Future.successful(None))
 
-      val result = upscanController.successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      val result = upscanController().successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.OK
     }
 
@@ -133,7 +143,7 @@ class UpscanControllerSpec extends UnitSpec with ErsTestHelper with GuiceOneAppP
       val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET")
       when(mockSessionService.getCallbackRecord(any(), any(), any())).thenReturn(Future.failed(new Exception("an error occured")))
 
-      val result = upscanController.successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
+      val result = upscanController().successODS(Fixtures.getMockSchemeTypeString).apply(fakeRequest)
       status(result) shouldBe Status.OK
     }
   }


### PR DESCRIPTION
# DDCE-184
## Bug fix
Finally fixed the long standing issue causing journey tests to fail. Issue was that because of the semi random nature of the upscan callback response, sometimes when trying to update the cache holding the list of CSV's there was a clash and only one would go through.

I've hotfixed a branch and the tests passed - https://build.tax.service.gov.uk/job/DDCE%20Live%20Services/job/Employment%20Related%20Securities/job/ers-checking-ui-journey-tests/

## Checklist PR Raiser Dan
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 
## Checklist PR Reviewer
 - [x]  I've verified every effort was made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've verified appropriate tests were included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've verified commits were squashed and rebased - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
 