### PR TITLE
DDCE-2053][SD][EH] Add failed mimeTypeCheck for CSV & ODS callback and fix tests

### DIFF
--- a/app/controllers/CheckingServiceController.scala
+++ b/app/controllers/CheckingServiceController.scala
@@ -44,6 +44,7 @@ class CheckingServiceController @Inject()(authAction: AuthAction,
                                           check_csv_file: views.html.check_csv_file,
                                           check_file: views.html.check_file,
                                           checking_success: views.html.checking_success,
+                                          invalid_file: views.html.file_upload_problem,
                                           override val global_error: views.html.global_error
                                          )(implicit ec: ExecutionContext, ersUtil: ERSUtil, override val appConfig: ApplicationConfig)
   extends FrontendController(mcc) with I18nSupport with BaseController with Logging {
@@ -173,6 +174,15 @@ class CheckingServiceController @Inject()(authAction: AuthAction,
 
   def showCheckingSuccessPage()(implicit request: Request[AnyRef], messages: Messages): Future[Result] = {
     Future.successful(Ok(checking_success(request, messages, appConfig)))
+  }
+
+  def checkingInvalidFilePage(): Action[AnyContent] = authAction.async {
+    implicit request =>
+      showInvalidFilePage()
+  }
+
+  def showInvalidFilePage()(implicit request: Request[AnyRef], messages: Messages): Future[Result] = {
+      Future.successful(BadRequest(invalid_file("ers.file_problem.title")(request, messages, appConfig)))
   }
 
   def formatErrorsPage(): Action[AnyContent] = authAction.async {

--- a/app/controllers/internal/UpscanCallbackController.scala
+++ b/app/controllers/internal/UpscanCallbackController.scala
@@ -45,7 +45,7 @@ class UpscanCallbackController @Inject()(sessionService: SessionService,
               UploadedSuccessfully(callback.uploadDetails.fileName, callback.downloadUrl.toExternalForm)
             case UpscanFailedCallback(_, details) =>
               logger.warn(s"[UpscanController][callbackCsv] Upload id: ${uploadId.value} failed. Reason: ${details.failureReason}. Message: ${details.message}")
-              Failed
+              if (details.message.contains("MIME type")) FailedMimeType else Failed
           }
           logger.info(s"[UpscanController][callbackCsv] Updating CSV callback for upload id: ${uploadId.value} to ${uploadStatus.getClass.getSimpleName}")
 
@@ -56,6 +56,7 @@ class UpscanCallbackController @Inject()(sessionService: SessionService,
             Ok
           }) recover {
             case NonFatal(e) =>
+              logger.error(s"Exception Thrown: ${e.getMessage()}")
               logger.error(s"[UpscanController][callbackCsv] Failed to update cache after Upscan callback for UploadID: ${uploadId.value}, " +
                 s"ScRef: $sessionId", e)
               InternalServerError("Exception occurred when attempting to store data")

--- a/app/controllers/internal/UpscanCallbackController.scala
+++ b/app/controllers/internal/UpscanCallbackController.scala
@@ -56,7 +56,6 @@ class UpscanCallbackController @Inject()(sessionService: SessionService,
             Ok
           }) recover {
             case NonFatal(e) =>
-              logger.error(s"Exception Thrown: ${e.getMessage()}")
               logger.error(s"[UpscanController][callbackCsv] Failed to update cache after Upscan callback for UploadID: ${uploadId.value}, " +
                 s"ScRef: $sessionId", e)
               InternalServerError("Exception occurred when attempting to store data")
@@ -79,7 +78,7 @@ class UpscanCallbackController @Inject()(sessionService: SessionService,
           case UpscanFailedCallback(_, details) =>
             logger.warn(s"[UpscanController][callbackOds] Callback for session id: $sessionId failed. " +
               s"Reason: ${details.failureReason}. Message: ${details.message}")
-            Failed
+            if (details.message.contains("MIME type")) FailedMimeType else Failed
         }
         logger.info(s"[UpscanController][callbackOds] Updating callback for session: $sessionId to ${uploadStatus.getClass.getSimpleName}")
         sessionService.updateCallbackRecord(uploadStatus)(headerCarrier, ec).map(_ => Ok) recover {

--- a/app/models/upscan/UploadStatus.scala
+++ b/app/models/upscan/UploadStatus.scala
@@ -22,6 +22,7 @@ sealed trait UploadStatus
 case object NotStarted extends UploadStatus
 case object InProgress extends UploadStatus
 case object Failed extends UploadStatus
+case object FailedMimeType extends UploadStatus
 
 case class UploadedSuccessfully(name: String, downloadUrl: String, noOfRows: Option[Int] = None) extends UploadStatus
 
@@ -37,6 +38,7 @@ object UploadStatus {
       case Some(JsString("NotStarted")) => JsSuccess(NotStarted)
       case Some(JsString("InProgress")) => JsSuccess(InProgress)
       case Some(JsString("Failed")) => JsSuccess(Failed)
+      case Some(JsString("FailedMimeType")) => JsSuccess(FailedMimeType)
       case Some(JsString("UploadedSuccessfully")) => Json.fromJson[UploadedSuccessfully](jsObject)(uploadedSuccessfullyFormat)
       case Some(value) => JsError(s"Unexpected value of _type: $value")
       case None => JsError("Missing _type field")
@@ -47,6 +49,7 @@ object UploadStatus {
     case NotStarted => JsObject(Map("_type" -> JsString("NotStarted")))
     case InProgress => JsObject(Map("_type" -> JsString("InProgress")))
     case Failed => JsObject(Map("_type" -> JsString("Failed")))
+    case FailedMimeType => JsObject(Map("_type" -> JsString("FailedMimeType")))
     case s: UploadedSuccessfully => Json.toJson(s)(uploadedSuccessfullyFormat).as[JsObject] + ("_type" -> JsString("UploadedSuccessfully"))
   }
 }

--- a/app/models/upscan/UpscanCsvCallback.scala
+++ b/app/models/upscan/UpscanCsvCallback.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Format, Json}
 case class UpscanCsvFilesCallback(uploadId: UploadId, uploadStatus: UploadStatus = NotStarted) {
   def isStarted: Boolean = uploadStatus != NotStarted
   def isComplete: Boolean = uploadStatus match {
-    case _: UploadedSuccessfully | Failed => true
+    case _: UploadedSuccessfully | Failed | FailedMimeType => true
     case _ => false
   }
 }
@@ -36,6 +36,8 @@ case class UpscanCsvFilesCallbackList(files: List[UpscanCsvFilesCallback]){
   def areAllFilesSuccessful(): Boolean = files.forall {
     _.uploadStatus.isInstanceOf[UploadedSuccessfully]
   }
+
+  def areAnyFilesWrongMimeType(): Boolean = files.filter(_.uploadStatus == FailedMimeType).nonEmpty
 }
 
 object UpscanCsvFilesCallbackList {

--- a/app/services/UpscanService.scala
+++ b/app/services/UpscanService.scala
@@ -47,7 +47,11 @@ class UpscanService @Inject()(upscanConnector: UpscanConnector, appConfig: Appli
     val callback = if (isCsvAndUploadId) callbackCsv(upscanId.get.uploadId) else callbackOds
     val success = if (isCsvAndUploadId) successCsv(upscanId.get.uploadId, scheme) else successOds(scheme)
     val failure = urlToString(controllers.routes.UpscanController.failure())
-    val upscanInitiateRequest: UpscanInitiateRequest = UpscanInitiateRequest(callback.absoluteURL(isSecure), success, failure)
+    val upscanInitiateRequest: UpscanInitiateRequest =
+      if (isCsvAndUploadId)
+        UpscanInitiateRequest(callback.absoluteURL(isSecure), success, failure, Some(1))
+      else 
+        UpscanInitiateRequest(callback.absoluteURL(isSecure), success, failure, Some(1), Some(10000000))
     upscanConnector.getUpscanFormData(upscanInitiateRequest)
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -28,6 +28,7 @@ POST  		/choose-scheme-or-arrangement-type			controllers.CheckingServiceControll
 
 GET			/confirmation			                    controllers.CheckingServiceController.checkingSuccessPage()
 GET			/format-errors				                controllers.CheckingServiceController.formatErrorsPage()
+GET         /invalid-file                               controllers.CheckingServiceController.checkingInvalidFilePage()
 
 GET			/error-report			    	            controllers.HtmlReportController.htmlErrorReportPage(isCsv: Boolean)
 

--- a/test/controllers/CheckCsvFilesControllerSpec.scala
+++ b/test/controllers/CheckCsvFilesControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
 import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, status}
-import views.html.{check_csv_file, check_file, check_file_type, checking_success, format_errors, global_error, scheme_type, select_csv_file_types, start}
+import views.html.{check_csv_file, check_file, check_file_type, checking_success, file_upload_problem, format_errors, global_error, scheme_type, select_csv_file_types, start}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
@@ -54,10 +54,11 @@ class CheckCsvFilesControllerSpec extends WordSpecLike with Matchers with Option
   val checkingSuccessView: checking_success = inject[checking_success]
   val selectFileTypeView: select_csv_file_types = inject[select_csv_file_types]
   val globalErrorView: global_error = inject[global_error]
+  val invalidErrorView: file_upload_problem = inject[file_upload_problem]
 
   def buildFakeCheckingServiceController(): CheckingServiceController =
     new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-      formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+      formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
       mockAnyContentAction
     }
 

--- a/test/controllers/CheckingServiceControllerTest.scala
+++ b/test/controllers/CheckingServiceControllerTest.scala
@@ -32,7 +32,7 @@ import play.api.mvc.{Call, DefaultMessagesControllerComponents, Result}
 import play.api.test.Helpers._
 import play.api.test.Injecting
 import uk.gov.hmrc.http.cache.client.CacheMap
-import views.html.{check_csv_file, check_file, check_file_type, checking_success, format_errors, global_error, scheme_type, select_csv_file_types, start}
+import views.html.{check_csv_file, check_file, check_file_type, checking_success, file_upload_problem, format_errors, global_error, scheme_type, select_csv_file_types, start}
 
 import scala.concurrent.Future
 
@@ -49,6 +49,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
   val checkingSuccessView: checking_success = inject[checking_success]
   val selectFileTypeView: select_csv_file_types = inject[select_csv_file_types]
   val globalErrorView: global_error = inject[global_error]
+  val invalidErrorView: file_upload_problem = inject[file_upload_problem]
 
   lazy val mcc: DefaultMessagesControllerComponents = testMCC(fakeApplication())
   implicit lazy val testMessages: MessagesImpl = MessagesImpl(i18n.Lang("en"), mcc.messagesApi)
@@ -57,7 +58,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         mockAnyContentAction
       }
 
@@ -79,7 +80,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         mockAnyContentAction
       }
 
@@ -103,7 +104,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(schemeRes: Boolean = true): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         when(mockErsUtil.cache(refEq(mockErsUtil.SCHEME_CACHE), anyString())(any(), any(), any()))
           .thenReturn(if (schemeRes) Future.successful(null) else Future.failed(new Exception))
         mockAnyContentAction
@@ -150,7 +151,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(fileTypeRes: Boolean = true): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
       when(mockErsUtil.fetch[String](refEq(mockErsUtil.FILE_TYPE_CACHE))(any(),any(),any()))
         .thenReturn(if (fileTypeRes) Future.successful("csv") else Future.failed(new NoSuchElementException))
 			mockAnyContentAction
@@ -186,7 +187,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(fileTypeRes: Boolean = true): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
       when(mockErsUtil.cache(refEq(mockErsUtil.FILE_TYPE_CACHE), anyString())(any(), any(), any()))
         .thenReturn(if (fileTypeRes) Future.successful(null) else Future.failed(new Exception))
 			mockAnyContentAction
@@ -243,7 +244,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(schemeRes: Boolean = true): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         when(mockErsUtil.cache(refEq(mockErsUtil.SCHEME_CACHE), anyString())(any(), any(), any()))
           .thenReturn(if (schemeRes) Future.successful(CacheMap("", Map.empty)) else Future.failed(new Exception))
         when(mockErsUtil.fetch[String](refEq(mockErsUtil.SCHEME_CACHE))(any(),any(),any()))
@@ -282,7 +283,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 
     def buildFakeCheckingServiceController(schemeRes: Boolean = true): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         when(mockErsUtil.cache(refEq(mockErsUtil.SCHEME_CACHE), anyString())(any(), any(), any()))
           .thenReturn(if (schemeRes) Future.successful(CacheMap("", Map.empty)) else Future.failed(new Exception))
         when(mockErsUtil.fetch[String](refEq(mockErsUtil.SCHEME_CACHE))(any(),any(),any()))
@@ -323,7 +324,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 																					 errorCount: String = "0"
 																					): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
         when(mockErsUtil.cache(refEq(mockErsUtil.SCHEME_CACHE), anyString())(any(), any(), any()))
           .thenReturn(if (schemeRes) Future.successful(CacheMap("", Map.empty)) else Future.failed(new Exception))
 
@@ -358,7 +359,7 @@ class CheckingServiceControllerTest extends WordSpecLike with Matchers with Opti
 																					 errorCount: String = "0"
 																					): CheckingServiceController =
       new CheckingServiceController(mockAuthAction, mockUpscanService, mockSessionService, mcc,
-        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, globalErrorView) {
+        formatErrorsView, startView, schemeTypeView, checkFileTypeView, checkCsvFileView, checkFileView, checkingSuccessView, invalidErrorView, globalErrorView) {
 
         when(mockErsUtil.cache(refEq(mockErsUtil.SCHEME_CACHE), anyString())(any(), any(), any()))
           .thenReturn(if (schemeRes) Future.successful(CacheMap("", Map.empty)) else Future.failed(new Exception))

--- a/test/controllers/UpscanControllerSpec.scala
+++ b/test/controllers/UpscanControllerSpec.scala
@@ -75,11 +75,12 @@ class UpscanControllerSpec extends WordSpecLike with Matchers with OptionValues
     }
 
     "return a 400 when one of the valid errorCodes is returned" in {
-      List("InvalidArgument", "EntityTooLarge", "EntityTooSmall").foreach {
+      List("EntityTooLarge", "EntityTooSmall").foreach {
         errorCode =>
           val fakeRequest = Fixtures.buildFakeRequestWithSessionId("GET", s"/failure?errorCode=$errorCode")
           val result: Future[Result] = upscanController().failure().apply(fakeRequest)
-          status(result) shouldBe Status.BAD_REQUEST
+          status(result) shouldBe Status.SEE_OTHER
+          result.futureValue.header.headers("Location") shouldBe routes.CheckingServiceController.checkingInvalidFilePage().toString
       }
     }
   }

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -52,7 +52,7 @@ class UpscanServiceSpec extends WordSpecLike with Matchers with OptionValues wit
       val callback: Call = controllers.internal.routes.UpscanCallbackController.callbackOds(sessionId)
       val success: String = "fakeUrlBase" +controllers.routes.UpscanController.successODS("csop").url
       val failure: String = "fakeUrlBase" +controllers.routes.UpscanController.failure().url
-      val expectedInitiateRequest: UpscanInitiateRequest = UpscanInitiateRequest(callback.absoluteURL(secure = true), success, failure)
+      val expectedInitiateRequest: UpscanInitiateRequest = UpscanInitiateRequest(callback.absoluteURL(secure = true), success, failure, Some(1), Some(10000000))
       val initiateRequestCaptor: ArgumentCaptor[UpscanInitiateRequest] = ArgumentCaptor.forClass(classOf[UpscanInitiateRequest])
 
       when(mockUpscanConnector.getUpscanFormData(initiateRequestCaptor.capture())(any[HeaderCarrier]))
@@ -71,7 +71,7 @@ class UpscanServiceSpec extends WordSpecLike with Matchers with OptionValues wit
       val callback: Call = controllers.internal.routes.UpscanCallbackController.callbackCsv(uploadId, sessionId)
       val success: String = "fakeUrlBase" +controllers.routes.UpscanController.successCSV(uploadId, "csop").url
       val failure: String = "fakeUrlBase" +controllers.routes.UpscanController.failure().url
-      val expectedInitiateRequest: UpscanInitiateRequest = UpscanInitiateRequest(callback.absoluteURL(secure = true), success, failure)
+      val expectedInitiateRequest: UpscanInitiateRequest = UpscanInitiateRequest(callback.absoluteURL(secure = true), success, failure, Some(1))
 			val initiateRequestCaptor: ArgumentCaptor[UpscanInitiateRequest] = ArgumentCaptor.forClass(classOf[UpscanInitiateRequest])
 
       when(mockUpscanConnector.getUpscanFormData(initiateRequestCaptor.capture())(any[HeaderCarrier]))


### PR DESCRIPTION
# DDCE-2053

Implemented fix for failedMimeType issue where upScan redirects to successCSV or successODS even though there is a failure 

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
