### PR TITLE
DDCE-5373: Update HMRC logo

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,11 +5,11 @@ object AppDependencies {
 
   val akkaVersion = "2.6.21" //Current 'bobby rule' not to upgrade past 2.6.21
   val bootstrapVersion = "7.23.0"
-  val mongoVersion = "1.4.0"
+  val mongoVersion = "1.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "commons-io"                  %  "commons-io"                 % "2.14.0",
+    "commons-io"                  %  "commons-io"                 % "2.15.1",
     "com.lightbend.akka"          %% "akka-stream-alpakka-csv"    % "4.0.0",
     "com.typesafe.akka"           %% "akka-stream"                % akkaVersion,
     "com.typesafe.akka"           %% "akka-slf4j"                 % akkaVersion,
@@ -22,18 +22,18 @@ object AppDependencies {
     "uk.gov.hmrc"                 %% "bootstrap-frontend-play-28" % bootstrapVersion,
     "uk.gov.hmrc"                 %% "domain"                     % "8.3.0-play-28",
     "uk.gov.hmrc"                 %% "tabular-data-validator"     % "1.8.0",
-    "uk.gov.hmrc"                 %% "play-frontend-hmrc"         % "7.22.0-play-28"
+    "uk.gov.hmrc"                 %% "play-frontend-hmrc-play-28" % "8.5.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.wiremock"           %  "wiremock-standalone"    % "3.3.1",
+    "org.wiremock"           %  "wiremock-standalone"    % "3.4.1",
     "com.typesafe.akka"      %% "akka-testkit"           % akkaVersion,
     "com.vladsch.flexmark"   %  "flexmark-all"           % "0.64.8",
-    "org.jsoup"              %  "jsoup"                  % "1.16.2",
-    "org.scalatestplus"      %% "mockito-4-11"           % "3.2.17.0",
+    "org.jsoup"              %  "jsoup"                  % "1.17.2",
+    "org.scalatestplus"      %% "mockito-5-10"           % "3.2.18.0",
     "uk.gov.hmrc"            %% "bootstrap-test-play-28" % bootstrapVersion,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % mongoVersion,
-    "org.scalatest"          %% "scalatest"              % "3.2.17"
+    "org.scalatest"          %% "scalatest"              % "3.2.18"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.15.0")
-addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.20")
-addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"  % "2.2.0")
-addSbtPlugin("org.scoverage"        % "sbt-scoverage"       % "2.0.9")
-addSbtPlugin("com.beautiful-scala"  % "sbt-scalastyle"      % "1.5.1")
-addSbtPlugin("com.timushev.sbt"     % "sbt-updates"         % "0.6.4")
-addSbtPlugin("io.github.irundaia"   % "sbt-sassify"         % "1.5.2")
-addSbtPlugin("uk.gov.hmrc"    % "sbt-accessibility-linter"  % "0.37.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"            % "3.20.0")
+addSbtPlugin("com.typesafe.play"    % "sbt-plugin"                % "2.8.21")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"        % "2.2.0")
+addSbtPlugin("org.scoverage"        % "sbt-scoverage"             % "2.0.9")
+addSbtPlugin("org.scalastyle"       %% "scalastyle-sbt-plugin"    % "1.0.0")
+addSbtPlugin("com.timushev.sbt"     % "sbt-updates"               % "0.6.4")
+addSbtPlugin("io.github.irundaia"   % "sbt-sassify"               % "1.5.2")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-accessibility-linter"  % "0.37.0")
 


### PR DESCRIPTION
# DDCE-5373

- update to use dependency `"uk.gov.hmrc" %% "play-frontend-hmrc-play-28" % "8.5.0"` which uses new HMRC logo:

<img width="994" alt="Screenshot 2024-02-27 at 15 53 02" src="https://github.com/hmrc/ers-checking-frontend/assets/125281117/54d7f3da-604f-4ec5-b7c5-f79a5580538e">
