### PR TITLE
DDCE-2158: Add file size logging for both ODS and CSV files

### DIFF
--- a/app/controllers/internal/FileSizeUtils.scala
+++ b/app/controllers/internal/FileSizeUtils.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.internal
+
+import play.api.Logging
+import services.audit.AuditEvents
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+
+case class FileSizeUtils @Inject()(val auditEvents: AuditEvents) extends Logging {
+
+  def logFileSize(fileSize: Int)(implicit hc: HeaderCarrier): Unit = {
+    auditEvents.auditFileSize(fileSize.toString)
+    logger.info(s"[FileSizeUtils][logFileSize]: file size: ${mapFileSizeToString(fileSize)}")
+  }
+
+  def mapFileSizeToString(fileSize: Int): String = {
+    val numberBytesInUnit = 1024.0
+    fileSize match {
+      case size: Int if size < numberBytesInUnit =>
+        f"$size%.2f bytes"
+      case size: Int if (Math.pow(numberBytesInUnit, 2.0) > size && size >= numberBytesInUnit) =>
+        val fileSizeInKb = size / numberBytesInUnit
+        f"${fileSizeInKb}%.2f KB (${fileSize} bytes)"
+      case size: Int if (Math.pow(numberBytesInUnit, 3.0) > size && size >= Math.pow(numberBytesInUnit, 2.0)) =>
+        val fileSizeInMb = size / Math.pow(numberBytesInUnit, 2.0)
+        f"${fileSizeInMb}%.2f MB (${fileSize} bytes)"
+      case size: Int if size >= Math.pow(numberBytesInUnit, 3.0) =>
+        val fileSizeInMb = size / Math.pow(numberBytesInUnit, 3.0)
+        f"${fileSizeInMb}%.2f GB (${fileSize} bytes)"
+    }
+  }
+
+}

--- a/app/models/upscan/UpscanCallback.scala
+++ b/app/models/upscan/UpscanCallback.scala
@@ -64,6 +64,6 @@ object UpscanCallback {
   }
 }
 
-case class UploadDetails(uploadTimestamp: Instant, checksum: String, fileMimeType: String, fileName: String)
+case class UploadDetails(uploadTimestamp: Instant, checksum: String, fileMimeType: String, fileName: String, size: Int)
 
 case class ErrorDetails(failureReason: String, message: String)

--- a/app/services/audit/AuditEvents.scala
+++ b/app/services/audit/AuditEvents.scala
@@ -24,7 +24,15 @@ import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class AuditEvents @Inject()(val auditConnector: AuditConnector) extends AuditService {
+class AuditEvents @Inject()(val auditConnector: AuditConnector)(implicit val ec: ExecutionContext) extends AuditService {
+
+  def auditFileSize(fileSize: String)(implicit hc: HeaderCarrier): Future[AuditResult] =
+    sendEvent(
+      "UploadFileSizeFromUpscanCallback",
+      Map(
+        "fileSize" -> fileSize
+      )
+    )
 
   def auditRunTimeError(exception : Throwable, contextInfo : String, sheetName : String)
                        (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AuditResult] = {

--- a/test/controllers/internal/FileSizeUtilsSpec.scala
+++ b/test/controllers/internal/FileSizeUtilsSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.internal
+
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{times, verify}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import services.audit.AuditEvents
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.DefaultAuditConnector
+import uk.gov.hmrc.play.audit.model.DataEvent
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class FileSizeUtilsSpec
+  extends AnyWordSpecLike
+    with Matchers
+    with MockitoSugar {
+
+  val mockAuditConnector: DefaultAuditConnector = mock[DefaultAuditConnector]
+  val mockAuditEvents: AuditEvents = new AuditEvents(mockAuditConnector)
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val fileSizeUtils: FileSizeUtils = new FileSizeUtils(mockAuditEvents)
+
+  "logFileSize" should {
+    "audit the file size with the scheme ref" in {
+      fileSizeUtils.logFileSize(100)
+      val eventCaptor = ArgumentCaptor.forClass(classOf[DataEvent])
+      verify(mockAuditConnector, times(1)).sendEvent(eventCaptor.capture())(any(), any())
+      eventCaptor.getValue.asInstanceOf[DataEvent].auditSource shouldBe "ers-checking-frontend"
+      eventCaptor.getValue.asInstanceOf[DataEvent].auditType shouldBe "UploadFileSizeFromUpscanCallback"
+      eventCaptor.getValue.asInstanceOf[DataEvent].detail shouldBe Map("fileSize" -> "100")
+    }
+  }
+
+  "mapFileSizeToString" should {
+    val fileSizeInBytesAndExpectedString: Seq[(Int, String)] = Seq(
+      (10, "10.00 bytes"),
+      (99, "99.00 bytes"),
+      (100, "100.00 bytes"),
+      (1000, "1000.00 bytes"),
+      (1024, "1.00 KB (1024 bytes)"),
+      (1126, "1.10 KB (1126 bytes)"),
+      (524288, "512.00 KB (524288 bytes)"),
+      (1048575, "1024.00 KB (1048575 bytes)"),
+      (1048576, "1.00 MB (1048576 bytes)"),
+      (1153433, "1.10 MB (1153433 bytes)"),
+      (107374182, "102.40 MB (107374182 bytes)"),
+      (1073741823, "1024.00 MB (1073741823 bytes)"),
+      (1073741824, "1.00 GB (1073741824 bytes)"),
+      (1181116006, "1.10 GB (1181116006 bytes)")
+    )
+
+    fileSizeInBytesAndExpectedString.foreach {
+      fileSizeAndExpectedString: (Int, String) =>
+        s"return the expected string: ${fileSizeAndExpectedString._2} when parsed a file size of: ${fileSizeAndExpectedString._1}" in {
+          fileSizeUtils.mapFileSizeToString(fileSizeAndExpectedString._1) shouldBe fileSizeAndExpectedString._2
+        }
+    }
+  }
+}

--- a/test/controllers/internal/UpscanCallbackControllerSpec.scala
+++ b/test/controllers/internal/UpscanCallbackControllerSpec.scala
@@ -46,13 +46,15 @@ class UpscanCallbackControllerSpec extends AnyWordSpecLike with Matchers with Op
 
   val sessionId = "sessionId"
 
-  val uploadDetails: UploadDetails = UploadDetails(Instant.now(), "checksum", "fileMimeType", "fileName")
+  val uploadDetails: UploadDetails = UploadDetails(Instant.now(), "checksum", "fileMimeType", "fileName", 100)
   val readyCallback: UpscanReadyCallback = UpscanReadyCallback(Reference("Reference"), new URL("https://callbackUrl.com"), uploadDetails)
   val failedCallback: UpscanFailedCallback = UpscanFailedCallback(Reference("Reference"), ErrorDetails("failureReason", "message"))
 
   def request(body: JsValue): FakeRequest[JsValue] = FakeRequest().withBody(body)
 
-  lazy val upscanCallbackController: UpscanCallbackController = new UpscanCallbackController(mockSessionCacheRepo, testMCC(fakeApplication()))
+  val fileSizeUtils: FileSizeUtils = mock[FileSizeUtils]
+
+  lazy val upscanCallbackController: UpscanCallbackController = new UpscanCallbackController(mockSessionCacheRepo, testMCC(fakeApplication()), fileSizeUtils)
 
   override def beforeEach(): Unit = {
     reset(mockSessionCacheRepo)


### PR DESCRIPTION
Example of logs:
```scala annotate
[FileSizeUtils][logFileSize]: file size: 142.00 bytes
```
This PR has a large amount of duplicate code from [this](https://github.com/hmrc/ers-returns-frontend/pull/192) PR.