### PR TITLE
DDCE-8784: Add logging to show csv radio button selected

### DIFF
--- a/app/controllers/CheckingServiceController.scala
+++ b/app/controllers/CheckingServiceController.scala
@@ -136,16 +136,18 @@ class CheckingServiceController @Inject() (
 
   def showCheckCsvFilePage()(implicit request: Request[AnyRef], hc: HeaderCarrier, messages: Messages): Future[Result] =
     (for {
-      scheme         <- sessionCacheService.fetchAndGetEntry[String](ersUtil.SCHEME_CACHE)
-      csvFilesList   <- sessionCacheService.fetchAndGetEntry[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
-      _               = logger.info(
-                          s"[CheckingServiceController][showCheckCsvFilePage]: The following " +
-                            s"sub schemes were selected to be uploaded: ${csvFilesList.ids.map(_.fileId).mkString(", ")}"
-                        )
-      refreshedList  <- resetIfNoneNotStarted(csvFilesList)
-      currentCsvFile  = refreshedList.ids.find(ids => ids.uploadStatus == NotStarted)
+      scheme             <- sessionCacheService.fetchAndGetEntry[String](ersUtil.SCHEME_CACHE)
+      csvFilesList       <- sessionCacheService.fetchAndGetEntry[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
+      allSelectedCsvFiles = csvFilesList.ids.map(_.fileId)
+      _                  <- auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
+      _                   = logger.info(
+                              s"[CheckingServiceController][showCheckCsvFilePage]: The following " +
+                                s"sub schemes were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"
+                            )
+      refreshedList      <- resetIfNoneNotStarted(csvFilesList)
+      currentCsvFile      = refreshedList.ids.find(ids => ids.uploadStatus == NotStarted)
       if currentCsvFile.isDefined
-      upscanResponse <- upscanService.getUpscanFormData(isCsv = true, scheme, currentCsvFile)
+      upscanResponse     <- upscanService.getUpscanFormData(isCsv = true, scheme, currentCsvFile)
     } yield Ok(
       check_csv_file(scheme, currentCsvFile.get.fileId)(request, messages, upscanResponse, appConfig, ersUtil)
     )) recover {

--- a/app/controllers/CheckingServiceController.scala
+++ b/app/controllers/CheckingServiceController.scala
@@ -139,7 +139,7 @@ class CheckingServiceController @Inject() (
       scheme             <- sessionCacheService.fetchAndGetEntry[String](ersUtil.SCHEME_CACHE)
       csvFilesList       <- sessionCacheService.fetchAndGetEntry[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
       allSelectedCsvFiles = csvFilesList.ids.map(_.fileId)
-      _                  <- auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
+      _                   = auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
       _                   = logger.info(
                               s"[CheckingServiceController][showCheckCsvFilePage]: The following " +
                                 s"sub schemes were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"

--- a/app/controllers/CheckingServiceController.scala
+++ b/app/controllers/CheckingServiceController.scala
@@ -138,6 +138,10 @@ class CheckingServiceController @Inject() (
     (for {
       scheme         <- sessionCacheService.fetchAndGetEntry[String](ersUtil.SCHEME_CACHE)
       csvFilesList   <- sessionCacheService.fetchAndGetEntry[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
+      _               = logger.info(
+                          s"[CheckingServiceController][showCheckCsvFilePage]: The following " +
+                            s"sub schemes were selected to be uploaded: ${csvFilesList.ids.map(_.fileId).mkString(", ")}"
+                        )
       refreshedList  <- resetIfNoneNotStarted(csvFilesList)
       currentCsvFile  = refreshedList.ids.find(ids => ids.uploadStatus == NotStarted)
       if currentCsvFile.isDefined

--- a/app/services/audit/AuditEvents.scala
+++ b/app/services/audit/AuditEvents.scala
@@ -27,6 +27,14 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuditEvents @Inject() (val auditConnector: AuditConnector)(implicit val ec: ExecutionContext)
     extends AuditService {
 
+  def auditSelectedCsvRadioButtons(selectedCsvFiles: Seq[String])(implicit hc: HeaderCarrier): Future[AuditResult] =
+    sendEvent(
+      "SelectedCsvRadioButtons",
+      Map(
+        "selectedCsvFiles" -> selectedCsvFiles.mkString(", ")
+      )
+    )
+
   def auditFileSize(fileSize: String)(implicit hc: HeaderCarrier): Future[AuditResult] =
     sendEvent(
       "UploadFileSizeFromUpscanCallback",

--- a/app/utils/CacheUtil.scala
+++ b/app/utils/CacheUtil.scala
@@ -26,7 +26,6 @@ trait CacheUtil {
   val SCHEME_CACHE: String                = "scheme-type"
   val FILE_TYPE_CACHE: String             = "check-file-type"
   val SCHEME_ERROR_COUNT_CACHE: String    = "scheme-error-count"
-  val FILE_NAME_NO_EXTN_CACHE: String     = "file-name-no-extn"
   val ERROR_LIST_CACHE: String            = "error-list"
   val ERROR_SUMMARY_CACHE: String         = "error-summary"
   val FORMAT_ERROR_CACHE: String          = "format_error"

--- a/test/controllers/CheckingServiceControllerTest.scala
+++ b/test/controllers/CheckingServiceControllerTest.scala
@@ -29,11 +29,13 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
-import play.api.i18n
+import play.api.{Logger, i18n}
 import play.api.i18n.{Messages, MessagesImpl}
 import play.api.mvc.{Call, DefaultMessagesControllerComponents, Result}
 import play.api.test.Helpers._
 import play.api.test.Injecting
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 import views.html._
 
 import scala.concurrent.Future
@@ -45,7 +47,8 @@ class CheckingServiceControllerTest
     with GuiceOneAppPerSuite
     with ErsTestHelper
     with Injecting
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
   lazy val mcc: DefaultMessagesControllerComponents = testMCC(fakeApplication())
   val formatErrorsView: format_errors               = inject[format_errors]
   val startView: start                              = inject[start]
@@ -59,6 +62,7 @@ class CheckingServiceControllerTest
   val invalidErrorView: file_upload_problem         = inject[file_upload_problem]
   val fileUploadErrorView: file_upload_error        = inject[file_upload_error]
   implicit lazy val testMessages: MessagesImpl      = MessagesImpl(i18n.Lang("en"), mcc.messagesApi)
+  val checkingServiceControllerLogger: Logger       = Logger(classOf[CheckingServiceController])
 
   "start Page GET" should {
 
@@ -424,7 +428,11 @@ class CheckingServiceControllerTest
           .thenReturn(if (schemeRes) Future.successful(UpscanCsvFilesList(csvFiles)) else Future.failed(new Exception))
         when(mockUpscanService.getUpscanFormData(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(UpscanInitiateResponse(Reference("ref"), Call("GET", "/"), Map.empty)))
+        when(mockAuditEvents.auditSelectedCsvRadioButtons(any())(any())).thenReturn(
+          Future.successful(AuditResult.Success)
+        )
         mockAnyContentAction
+        override val logger: Logger = checkingServiceControllerLogger
       }
 
     "give a call to showCheckCsvFilePage if user is authenticated" in {
@@ -477,6 +485,29 @@ class CheckingServiceControllerTest
       )
       status(result)           shouldBe Status.SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.CheckingServiceController.fileUploadError().url)
+    }
+
+    "log out selected radio buttons" in {
+
+      val controllerUnderTest = buildFakeCheckingServiceController(
+        csvFiles = Seq.fill(3)(
+          UpscanIds(UploadId("id"), "fileId123", InProgress)
+        )
+      )
+
+      val expectedLogMessage =
+        "[CheckingServiceController][showCheckCsvFilePage]: The following sub schemes were selected to be uploaded: fileId123, fileId123, fileId123"
+
+      withCaptureOfLoggingFrom(checkingServiceControllerLogger) { captureEvents =>
+        val result: Result =
+          await(controllerUnderTest.checkCsvFilePage().apply(Fixtures.buildFakeRequestWithSessionId("GET")))
+        result.header.status shouldBe Status.OK
+        assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
+      }
+
+      verify(mockAuditEvents, times(1)).auditSelectedCsvRadioButtons(refEq(Seq("fileId123", "fileId123", "fileId123")))(
+        any()
+      )
     }
 
   }

--- a/test/helpers/ErsTestHelper.scala
+++ b/test/helpers/ErsTestHelper.scala
@@ -144,7 +144,6 @@ trait ErsTestHelper extends MockitoSugar {
   when(mockErsUtil.SCHEME_CACHE).thenReturn("scheme-type")
   when(mockErsUtil.FILE_TYPE_CACHE).thenReturn("check-file-type")
   when(mockErsUtil.SCHEME_ERROR_COUNT_CACHE).thenReturn("scheme-error-count")
-  when(mockErsUtil.FILE_NAME_NO_EXTN_CACHE).thenReturn("file-name-no-extn")
   when(mockErsUtil.ERROR_LIST_CACHE).thenReturn("error-list")
   when(mockErsUtil.ERROR_SUMMARY_CACHE).thenReturn("error-summary")
   when(mockErsUtil.FORMAT_ERROR_CACHE).thenReturn("format_error")


### PR DESCRIPTION
Add logging for selected radio buttons, example of log:
```
[CheckingServiceController][showCheckCsvFilePage]: The following sub schemes were selected to be uploaded: OTHER_GRANTS, OTHER_OPTIONS, OTHER_RESTRICTED, OTHER_NOTIONAL, OTHER_ENCHANCEMENT]
```

Also removed `FILE_NAME_NO_EXTN_CACHE` as it wasnt used anywhere. 